### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Every session, your AI starts over. Your decisions, your preferences, your proje
 
 **Jarvis Orb** gives your AI a persistent brain and shows its thought process as a living orb on your desktop.
 
+[![jarvis-orb MCP server](https://glama.ai/mcp/servers/whynowlab/jarvis-orb/badges/card.svg)](https://glama.ai/mcp/servers/whynowlab/jarvis-orb)
+
 | | Without Jarvis Orb | With Jarvis Orb |
 |---|---|---|
 | **Context** | Every session starts from zero | Carries over automatically |


### PR DESCRIPTION
This PR adds a badge for the [jarvis-orb](https://glama.ai/mcp/servers/whynowlab/jarvis-orb) server listing in Glama MCP server directory.

[![jarvis-orb MCP server](https://glama.ai/mcp/servers/whynowlab/jarvis-orb/badges/card.svg)](https://glama.ai/mcp/servers/whynowlab/jarvis-orb)

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.